### PR TITLE
Add metadata.

### DIFF
--- a/meta/libraries.json
+++ b/meta/libraries.json
@@ -1,5 +1,6 @@
 {
     "key": "assert",
+    "boost-version": "1.27.0",
     "name": "Assert",
     "authors": [
         "Peter Dimov"


### PR DESCRIPTION
This adds the metadata I've been discussing on the list recently. I want to get it into assert so I can use it to add it to the library list on the site. Should it have a backdated `boost-version` field for an earlier version of boost? The field represents the first version of boost to contain the library.
