### PR TITLE
Correct spelling of "suppress"

### DIFF
--- a/test/assert_test.cpp
+++ b/test/assert_test.cpp
@@ -58,7 +58,7 @@ void test_disabled()
     BOOST_ASSERT(p);
     BOOST_ASSERT_MSG(p, "msg");
 
-    // supress warnings
+    // suppress warnings
     p = &x;
     p = &p;
 }


### PR DESCRIPTION
"Suppress" is spelled with two P's, even in British English.