### PR TITLE
Added BOOST_ASSERT_IS_VOID macro

### DIFF
--- a/assert.html
+++ b/assert.html
@@ -122,7 +122,7 @@
 void MyContainer::erase(iterator i)
 {
   //Some sanity checks, data must be ordered
-  #ifndef BOOST_ASSERT_IS_EMPTY
+  #ifndef BOOST_ASSERT_IS_VOID
      if(i != c.begin()){
         iterator prev = i;
         --prev;

--- a/assert.html
+++ b/assert.html
@@ -22,6 +22,7 @@
             <a href="#BOOST_ASSERT_MSG">BOOST_ASSERT_MSG</a><br />
             <a href="#BOOST_VERIFY">BOOST_VERIFY</a><br />
             <a href="#BOOST_VERIFY_MSG">BOOST_VERIFY_MSG</a><br />
+            <a href="#BOOST_ASSERT_IS_VOID">BOOST_ASSERT_IS_VOID</a><br />            
         </p>
             
 <h2><a name="BOOST_ASSERT">BOOST_ASSERT</a></h2>
@@ -113,8 +114,40 @@
 			defined, to <code>BOOST_ASSERT_MSG(expr,msg)</code> when it's not.</p>
 	    <hr />
 		<p>
+<h2><a name="BOOST_ASSERT_IS_VOID">BOOST_ASSERT_IS_VOID</a></h2>
+		<p>The macro <code>BOOST_ASSERT_IS_VOID</code> is defined when <code>BOOST_ASSERT</code> and <code>BOOST_ASSERT_MSG</code>, are expanded to <code>((void)0)</code>.
+      	This macro is useful to avoid compiling and potentially running code that is only intended to prepare data to be used in the assertion.</p>
+		<blockquote>
+		<pre>
+void MyContainer::erase(iterator i)
+{
+  //Some sanity checks, data must be ordered
+  #ifndef BOOST_ASSERT_IS_EMPTY
+     if(i != c.begin()){
+        iterator prev = i;
+        --prev;
+        BOOST_ASSERT(*prev < *i);
+     }
+     else if(i != c.end()){
+        iterator next = i;
+        ++next;
+        BOOST_ASSERT(*i < *next);
+     }
+  #endif
+  this->erase_impl(i);
+}
+</pre>
+		</blockquote>         
+      
+      
+		<p>&bull; By default, <code>BOOST_ASSERT_IS_VOID</code> is defined if <code>NDEBUG</code> is defined.</p>
+		<p>&bull; If the macro <code>BOOST_DISABLE_ASSERTS</code> is defined <code>BOOST_ASSERT_IS_VOID</code> is always defined.</p>
+		<p>&bull; If the macro <code>BOOST_ENABLE_ASSERT_HANDLER</code> is defined <code>BOOST_ASSERT_IS_VOID</code> is never defined.</p>
+		<p>&bull; If the macro <code>BOOST_ENABLE_ASSERT_DEBUG_HANDLER</code>, then <code>BOOST_ASSERT_IS_VOID</code> is defined when <code>NDEBUG</code> is defined.</p>
+	    <hr />
+		<p>
 			<small>Copyright © 2002, 2007, 2014 by Peter Dimov.&nbsp; Copyright © 2011 
-        by Beman Dawes. Distributed under the Boost Software 
+        by Beman Dawes.&nbsp; Copyright © 2015 by Ion Gaztanaga. Distributed under the Boost Software 
 				License, Version 1.0. See accompanying file <a href="../../LICENSE_1_0.txt">LICENSE_1_0.txt</a>
 				or copy at <a href="http://www.boost.org/LICENSE_1_0.txt">http://www.boost.org/LICENSE_1_0.txt</a>.</small></p>
 	</body>

--- a/include/boost/assert.hpp
+++ b/include/boost/assert.hpp
@@ -3,10 +3,12 @@
 //                     BOOST_ASSERT_MSG(expr, msg)
 //                     BOOST_VERIFY(expr)
 //                     BOOST_VERIFY_MSG(expr, msg)
+//                     BOOST_ASSERT_IS_VOID
 //
 //  Copyright (c) 2001, 2002 Peter Dimov and Multi Media Ltd.
 //  Copyright (c) 2007, 2014 Peter Dimov
 //  Copyright (c) Beman Dawes 2011
+//  Copyright (c) 2015 Ion Gaztanaga
 //
 //  Distributed under the Boost Software License, Version 1.0.
 //  See accompanying file LICENSE_1_0.txt or copy at
@@ -24,16 +26,18 @@
 //
 
 //
-// BOOST_ASSERT, BOOST_ASSERT_MSG
+// BOOST_ASSERT, BOOST_ASSERT_MSG, BOOST_ASSERT_IS_VOID
 //
 
 #undef BOOST_ASSERT
 #undef BOOST_ASSERT_MSG
+#undef BOOST_ASSERT_IS_VOID
 
 #if defined(BOOST_DISABLE_ASSERTS) || ( defined(BOOST_ENABLE_ASSERT_DEBUG_HANDLER) && defined(NDEBUG) )
 
 # define BOOST_ASSERT(expr) ((void)0)
 # define BOOST_ASSERT_MSG(expr, msg) ((void)0)
+# define BOOST_ASSERT_IS_VOID
 
 #elif defined(BOOST_ENABLE_ASSERT_HANDLER) || ( defined(BOOST_ENABLE_ASSERT_DEBUG_HANDLER) && !defined(NDEBUG) )
 
@@ -55,6 +59,9 @@ namespace boost
 
 # define BOOST_ASSERT(expr) assert(expr)
 # define BOOST_ASSERT_MSG(expr, msg) assert((expr)&&(msg))
+#if defined(NDEBUG)
+# define BOOST_ASSERT_IS_VOID
+#endif
 
 #endif
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -14,6 +14,7 @@ test-suite "assert"
         [ run assert_test.cpp ]
         [ run current_function_test.cpp : : : <test-info>always_show_run_output ]
         [ run verify_test.cpp ]
+        [ run assert_is_void_test.cpp ]
         # expansion tests are in exp/ so that there is a backslash in the path on Windows
         [ run exp/assert_exp_test.cpp ]
         [ run exp/assert_msg_exp_test.cpp ]

--- a/test/assert_is_void_test.cpp
+++ b/test/assert_is_void_test.cpp
@@ -17,7 +17,7 @@
 #include <boost/assert.hpp>
 
 #ifdef BOOST_ASSERT_IS_VOID
-#error "Error: BOOST_ASSERT should be void in NDEBUG"
+#error "BOOST_ASSERT should NOT be void if NDEBUG is not defined"
 #endif
 
 // default case, NDEBUG
@@ -27,7 +27,7 @@
 #include <boost/assert.hpp>
 
 #ifndef BOOST_ASSERT_IS_VOID
-#error "BOOST_ASSERT should NOT be void if NDEBUG is not defined"
+#error "Error: BOOST_ASSERT should be void in NDEBUG"
 #endif
 
 // BOOST_DISABLE_ASSERTS, !NDEBUG

--- a/test/assert_is_void_test.cpp
+++ b/test/assert_is_void_test.cpp
@@ -27,7 +27,7 @@
 #include <boost/assert.hpp>
 
 #ifndef BOOST_ASSERT_IS_VOID
-#error "Error: BOOST_ASSERT should be void in NDEBUG"
+#error "BOOST_ASSERT should NOT be void if NDEBUG is not defined"
 #endif
 
 // BOOST_DISABLE_ASSERTS, !NDEBUG

--- a/test/assert_is_void_test.cpp
+++ b/test/assert_is_void_test.cpp
@@ -1,0 +1,108 @@
+//
+//  assert_is_void_test.cpp - tests BOOST_ASSERT_IS_VOID
+//
+//  Copyright (c) 2015 Ion Gaztanaga
+//
+// Distributed under the Boost Software License, Version 1.0.
+// See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt
+//
+
+#include <boost/config.hpp>
+
+// default case, !NDEBUG
+// BOOST_ASSERT(x) -> assert(x)
+
+#undef NDEBUG
+#include <boost/assert.hpp>
+
+#ifdef BOOST_ASSERT_IS_VOID
+#error "Error: BOOST_ASSERT should be void in NDEBUG"
+#endif
+
+// default case, NDEBUG
+// BOOST_ASSERT(x) -> assert(x)
+
+#define NDEBUG
+#include <boost/assert.hpp>
+
+#ifndef BOOST_ASSERT_IS_VOID
+#error "Error: BOOST_ASSERT should be void in NDEBUG"
+#endif
+
+// BOOST_DISABLE_ASSERTS, !NDEBUG
+// BOOST_ASSERT(x) -> ((void)0)
+
+#define BOOST_DISABLE_ASSERTS
+
+#undef NDEBUG
+#include <boost/assert.hpp>
+
+#ifndef BOOST_ASSERT_IS_VOID
+#error "Error: BOOST_ASSERT should be void with BOOST_DISABLE_ASSERTS"
+#endif
+
+// BOOST_DISABLE_ASSERTS, NDEBUG
+// BOOST_ASSERT(x) -> ((void)0)
+
+#define NDEBUG
+#include <boost/assert.hpp>
+
+#ifndef BOOST_ASSERT_IS_VOID
+#error "Error: BOOST_ASSERT should be void with BOOST_DISABLE_ASSERTS and NDEBUG"
+#endif
+
+#undef BOOST_DISABLE_ASSERTS
+
+// BOOST_ENABLE_ASSERT_HANDLER, !NDEBUG
+// BOOST_ASSERT(expr) -> (BOOST_LIKELY(!!(expr))? ((void)0): ::boost::assertion_failed(#expr, BOOST_CURRENT_FUNCTION, __FILE__, __LINE__))
+
+#define BOOST_ENABLE_ASSERT_HANDLER
+
+#undef NDEBUG
+#include <boost/assert.hpp>
+
+#ifdef BOOST_ASSERT_IS_VOID
+#error "Error: BOOST_ASSERT should NOT be void with BOOST_ENABLE_ASSERT_HANDLER"
+#endif
+
+// BOOST_ENABLE_ASSERT_HANDLER, NDEBUG
+// BOOST_ASSERT(expr) -> (BOOST_LIKELY(!!(expr))? ((void)0): ::boost::assertion_failed(#expr, BOOST_CURRENT_FUNCTION, __FILE__, __LINE__))
+
+#define NDEBUG
+#include <boost/assert.hpp>
+
+#ifdef BOOST_ASSERT_IS_VOID
+#error "Error: BOOST_ASSERT should NOT be void with BOOST_ENABLE_ASSERT_HANDLER"
+#endif
+
+#undef BOOST_ENABLE_ASSERT_HANDLER
+
+// BOOST_ENABLE_ASSERT_DEBUG_HANDLER, !NDEBUG
+// same as BOOST_ENABLE_ASSERT_HANDLER
+
+#define BOOST_ENABLE_ASSERT_DEBUG_HANDLER
+
+#undef NDEBUG
+#include <boost/assert.hpp>
+
+#ifdef BOOST_ASSERT_IS_VOID
+#error "Error: BOOST_ASSERT should NOT be void with BOOST_ENABLE_ASSERT_DEBUG_HANDLER and !NDEBUG"
+#endif
+
+// BOOST_ENABLE_ASSERT_DEBUG_HANDLER, NDEBUG
+// BOOST_ASSERT(x) -> ((void)0)
+
+#define NDEBUG
+#include <boost/assert.hpp>
+
+#ifndef BOOST_ASSERT_IS_VOID
+#error "Error: BOOST_ASSERT should be void with BOOST_ENABLE_ASSERT_DEBUG_HANDLER and NDEBUG"
+#endif
+
+#undef BOOST_ENABLE_ASSERT_DEBUG_HANDLER
+
+int main()
+{
+    return 0;
+}


### PR DESCRIPTION
Sometimes I need to write assertions that require some data preprocessing that should not be compiled/run when Boost.Assert is just a ((void)0) expression. This is a proposal to implement a macro that could help with these use cases. The name of the macro and the implementation are not important, this is just a proposal.