### PR TITLE
Explicitly cast to char * to appease clang-tidy

### DIFF
--- a/include/boost/assert/source_location.hpp
+++ b/include/boost/assert/source_location.hpp
@@ -86,7 +86,14 @@ template<class E, class T> std::basic_ostream<E, T> & operator<<( std::basic_ost
 
 #else
 
-#  define BOOST_CURRENT_LOCATION ::boost::source_location(__FILE__, __LINE__, BOOST_CURRENT_FUNCTION)
+// Explicitly cast to const char * here to silence clang-tidy warning
+// (https://bugs.llvm.org/show_bug.cgi?id=28480)
+#define BOOST_CURRENT_LOCATION                              \
+    ::boost::source_location(                               \
+        __FILE__,                                           \
+        __LINE__,                                           \
+        static_cast<const char *>( BOOST_CURRENT_FUNCTION ) \
+    )
 
 #endif
 


### PR DESCRIPTION
The motivation for this change is that running:

~~~cpp
#include <iostream>

#include <boost/assert/source_location.hpp>

int main() {
    ::std::cerr << BOOST_CURRENT_LOCATION << "\n";
}
~~~

&hellip;through `clang-tidy` with `-checks=hicpp-no-array-decay` (eg see [this Godbolt](https://godbolt.org/z/Md8qcY)) gives:

~~~no-highlight
<source>:6:20: warning: do not implicitly decay an array into a pointer; consider using gsl::array_view or an explicit cast instead [hicpp-no-array-decay]
    ::std::cerr << BOOST_CURRENT_LOCATION << "\n";
                   ^
/opt/compiler-explorer/libs/boost_1_75_0/boost/assert/source_location.hpp:89:79: note: expanded from macro 'BOOST_CURRENT_LOCATION'
#  define BOOST_CURRENT_LOCATION ::boost::source_location(__FILE__, __LINE__, BOOST_CURRENT_FUNCTION)
                                                                              ^
/opt/compiler-explorer/libs/boost_1_75_0/boost/current_function.hpp:37:33: note: expanded from macro 'BOOST_CURRENT_FUNCTION'
# define BOOST_CURRENT_FUNCTION __PRETTY_FUNCTION__
                                ^
28 warnings generated.
Suppressed 27 warnings (27 in non-user code).
Use -header-filter=.* to display errors from all non-system headers. Use -system-headers to display errors from system headers as well.
~~~

This also manifests as a `clang-tidy` warning in code that uses `BOOST_THROW_EXCEPTION`.

This change silences the warning.