### PR TITLE
simplify path in cmake_subdir_test

### DIFF
--- a/test/cmake_subdir_test/CMakeLists.txt
+++ b/test/cmake_subdir_test/CMakeLists.txt
@@ -6,7 +6,7 @@ cmake_minimum_required(VERSION 3.5...3.16)
 
 project(cmake_subdir_test LANGUAGES CXX)
 
-add_subdirectory(../../../assert boostorg/assert)
+add_subdirectory(../.. boostorg/assert)
 add_subdirectory(../../../config boostorg/config)
 
 add_executable(main main.cpp)


### PR DESCRIPTION
Follow the pattern from other libraries, such as: https://github.com/boostorg/bind/blob/develop/test/cmake_subdir_test/CMakeLists.txt

Solves the problem, if the repo's directory name happens to be different.