### PR TITLE
Introduced BOOST_ASSERT_HANDLER_IS_NORETURN to make sure short-circuit work

### DIFF
--- a/include/boost/assert.hpp
+++ b/include/boost/assert.hpp
@@ -39,14 +39,20 @@
 # define BOOST_ASSERT_MSG(expr, msg) ((void)0)
 # define BOOST_ASSERT_IS_VOID
 
-#elif defined(BOOST_ENABLE_ASSERT_HANDLER) || ( defined(BOOST_ENABLE_ASSERT_DEBUG_HANDLER) && !defined(NDEBUG) )
+#elif defined(BOOST_ENABLE_ASSERT_HANDLER) || defined(BOOST_ENABLE_ASSERT_HANDLER_NORETURN) || ( defined(BOOST_ENABLE_ASSERT_DEBUG_HANDLER) && !defined(NDEBUG) ) || ( defined(BOOST_ENABLE_ASSERT_DEBUG_HANDLER_NORETURN) && !defined(NDEBUG) )
 
 #include <boost/config.hpp> // for BOOST_LIKELY
 #include <boost/current_function.hpp>
 
 namespace boost
 {
+#if defined(BOOST_ENABLE_ASSERT_HANDLER_NORETURN) || defined(BOOST_ENABLE_ASSERT_DEBUG_HANDLER_NORETURN)
+    [[noreturn]]
+#endif
     void assertion_failed(char const * expr, char const * function, char const * file, long line); // user defined
+#if defined(BOOST_ENABLE_ASSERT_HANDLER_NORETURN) || defined(BOOST_ENABLE_ASSERT_DEBUG_HANDLER_NORETURN)
+    [[noreturn]]
+#endif
     void assertion_failed_msg(char const * expr, char const * msg, char const * function, char const * file, long line); // user defined
 } // namespace boost
 

--- a/include/boost/assert.hpp
+++ b/include/boost/assert.hpp
@@ -39,19 +39,19 @@
 # define BOOST_ASSERT_MSG(expr, msg) ((void)0)
 # define BOOST_ASSERT_IS_VOID
 
-#elif defined(BOOST_ENABLE_ASSERT_HANDLER) || defined(BOOST_ENABLE_ASSERT_HANDLER_NORETURN) || ( defined(BOOST_ENABLE_ASSERT_DEBUG_HANDLER) && !defined(NDEBUG) ) || ( defined(BOOST_ENABLE_ASSERT_DEBUG_HANDLER_NORETURN) && !defined(NDEBUG) )
+#elif defined(BOOST_ENABLE_ASSERT_HANDLER) || ( defined(BOOST_ENABLE_ASSERT_DEBUG_HANDLER) && !defined(NDEBUG) )
 
 #include <boost/config.hpp> // for BOOST_LIKELY
 #include <boost/current_function.hpp>
 
 namespace boost
 {
-#if defined(BOOST_ENABLE_ASSERT_HANDLER_NORETURN) || defined(BOOST_ENABLE_ASSERT_DEBUG_HANDLER_NORETURN)
-    [[noreturn]]
+#if defined(BOOST_ASSERT_HANDLER_IS_NORETURN)
+    BOOST_NORETURN
 #endif
     void assertion_failed(char const * expr, char const * function, char const * file, long line); // user defined
-#if defined(BOOST_ENABLE_ASSERT_HANDLER_NORETURN) || defined(BOOST_ENABLE_ASSERT_DEBUG_HANDLER_NORETURN)
-    [[noreturn]]
+#if defined(BOOST_ASSERT_HANDLER_IS_NORETURN)
+    BOOST_NORETURN
 #endif
     void assertion_failed_msg(char const * expr, char const * msg, char const * function, char const * file, long line); // user defined
 } // namespace boost


### PR DESCRIPTION
## Phenomenon

This program:

```
#define BOOST_ENABLE_ASSERT_HANDLER
#include <boost/heap/fibonacci_heap.hpp>

int main(){
    boost::heap::fibonacci_heap<int> hp;
    hp.push(1);
    hp.pop();
}
```

warns this on gcc 12+:

```
In file included from /opt/wandbox/boost-1.81.0-gcc-12.3.0/include/boost/heap/fibonacci_heap.hpp:16,
                 from prog.cc:2:
In member function 'T& boost::array<T, N>::operator[](size_type) [with T = boost::heap::detail::marked_heap_node<int>*; long unsigned int N = 64]',
    inlined from 'void boost::heap::fibonacci_heap<T, A0, A1, A2, A3, A4>::consolidate() [with T = int; A0 = boost::parameter::void_; A1 = boost::parameter::void_; A2 = boost::parameter::void_; A3 = boost::parameter::void_; A4 = boost::parameter::void_]' at /opt/wandbox/boost-1.81.0-gcc-12.3.0/include/boost/heap/fibonacci_heap.hpp:715:20:
/opt/wandbox/boost-1.81.0-gcc-12.3.0/include/boost/array.hpp:117:68: warning: array subscript 64 is above array bounds of 'boost::heap::detail::marked_heap_node<int>* [64]' [-Warray-bounds]
  117 |             return BOOST_ASSERT_MSG( i < N, "out of range" ), elems[i];
      |                                                               ~~~~~^
/opt/wandbox/boost-1.81.0-gcc-12.3.0/include/boost/array.hpp: In member function 'void boost::heap::fibonacci_heap<T, A0, A1, A2, A3, A4>::consolidate() [with T = int; A0 = boost::parameter::void_; A1 = boost::parameter::void_; A2 = boost::parameter::void_; A3 = boost::parameter::void_; A4 = boost::parameter::void_]':
/opt/wandbox/boost-1.81.0-gcc-12.3.0/include/boost/array.hpp:62:11: note: while referencing 'boost::array<boost::heap::detail::marked_heap_node<int>*, 64>::elems'
   62 |         T elems[N];    // fixed-size array of elements of type T
      |           ^~~~~
```

## Background

This happens because, though https://github.com/boostorg/array/blob/develop/include/boost/array.hpp mentions `return BOOST_ASSERT_MSG( i < N, "out of range" ), elems[i]`, but it does not short-circuit.

## Description

This pull request adds new flag named BOOST_ENABLE_ASSERT_HANDLER_NORETURN. When it is defined, boost_assertion_failed is declared with `[[noreturn]]`. Then gcc can understand the short-circuit that BOOST_ASSERT_MSG does not return when the assertion fails.

Of course, the user's boost_assertion_failed must throw, which can be breaking, so a new flag must be used and BOOST_ENABLE_ASSERT_HANDLER cannot be used automatically.